### PR TITLE
add Paused to running states

### DIFF
--- a/vboxpower.py
+++ b/vboxpower.py
@@ -21,7 +21,7 @@ RESPONSES = {
     }
 }
 
-RUNNING_STATES = ["Starting", "FirstOnline", "Running", "LastOnline"]
+RUNNING_STATES = ["Starting", "FirstOnline", "Running", "LastOnline", "Paused"]
 STOPPED_STATES = ["PoweredOff", "Saved", "Aborted"]
 
 def check_machine_status(machine):


### PR DESCRIPTION
Provide compatibility with VirtualBox v.7
In VirtualBox v.7, Paused is known as a running state. Fix unknown status in VirtualBox v.7